### PR TITLE
Update branding to “Resonate”

### DIFF
--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -89,17 +89,18 @@ const Welcome: React.FC = () => {
       <Container maxWidth="md">
         <div className="text-center mb-8">
           {/* Logo */}
-          <div className="flex justify-center mb-6">
-            <div className="w-20 h-20 rounded-full bg-primary-600 flex items-center justify-center">
-              {/* Replace with your actual logo */}
-              <span className="text-3xl font-bold text-white">MC</span>
-            </div>
-          </div>
+           <div className="w-40 h-40 flex items-center justify-center">
+              <img 
+                src="/images/logo_ry_3.png" 
+                alt="Resonate Logo" 
+                className="w-full h-full object-contain"
+
+
           <h1 className="text-4xl font-extrabold text-gray-900 dark:text-white">
-            MusicConnect
+            Resonate
           </h1>
           <p className="mt-2 text-lg text-gray-600 dark:text-gray-400">
-            Connect with others through the music you love
+            Connect with others through music!
           </p>
         </div>
 

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -94,7 +94,8 @@ const Welcome: React.FC = () => {
                 src="/images/logo_ry_3.png" 
                 alt="Resonate Logo" 
                 className="w-full h-full object-contain"
-
+              />
+          </div> 
 
           <h1 className="text-4xl font-extrabold text-gray-900 dark:text-white">
             Resonate

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -53,10 +53,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   const toggleTheme = () => {
     setTheme(theme === 'dark' ? 'light' : 'dark');
   };
-
   return (
     <div className={theme === 'dark' ? 'dark' : 'light'}>
-      <AppLayout hideNav={hideNav || isPublicRoute} title="MusicConnect">
+      <AppLayout hideNav={hideNav || isPublicRoute} title="Resonate">
         <Component {...pageProps} toggleTheme={toggleTheme} />
       </AppLayout>
     </div>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,10 +4,10 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="/images/default-album.svg" type="image/svg+xml" sizes="any" />
+        <link rel="icon" href="/images/logo_ry_3.png" type="image/png" />
+        <link rel="icon" href="/images/logo_ry_3.png" type="image/png" sizes="any" />
         <meta name="theme-color" content="#667eea" />
-        <meta name="description" content="MusicConnect - Share your daily songs and discover new music with friends" />
+        <meta name="description" content="Resonate - Share your daily songs and discover new music with friends" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
This PR applies our new “Resonate” branding across the site:
Replaces the logo, heading, and sub-text in Welcome.tsx
Sets the app title to “Resonate” in _app.tsx
Adds the Resonate favicon and meta tags in _document.tsx